### PR TITLE
Links de navegação

### DIFF
--- a/4noobsDocs/1-Historia.md
+++ b/4noobsDocs/1-Historia.md
@@ -24,7 +24,7 @@
 
 Flask é um micro-framework web escrito em python e baseado na biblioteca WSGI Werkzeug e na biblioteca de Jinja2, criado por **Armin Ronacher** em 1 de abril de 2010.
 
-[Inicio](../README.md), [Anterior](../README.md), [Proximo](./2-Instalacao.md)
+[Início](../README.md), [Próximo](./2-Instalacao.md)
 
 
 <p align="center">

--- a/4noobsDocs/2-Instalacao.md
+++ b/4noobsDocs/2-Instalacao.md
@@ -154,7 +154,7 @@ sudo pacman -S pycharm-community-edition
 
 Caso você saiba de mais alguma IDE que não esteja aqui faça um PR.
 
-[Inicio](../README.md), [Anterior](./1-Historia.md), [Proximo](./3-Comeco.md)
+[Início](../README.md), [Anterior](./1-Historia.md), [Próximo](./3-Comeco.md)
 
 
 <p align="center">

--- a/4noobsDocs/3-Comeco.md
+++ b/4noobsDocs/3-Comeco.md
@@ -255,6 +255,8 @@ app.logger.error('Um error aconteceu.')
 
 Sendo feito...
 
+[Início](../README.md), [Anterior](./2-Instalacao.md), [Próximo](./4-Desafios.md)
+
 
 <p align="center">
   <a href="https://github.com/he4rt/4noobs" target="_blank">

--- a/4noobsDocs/4-Desafios.md
+++ b/4noobsDocs/4-Desafios.md
@@ -29,7 +29,7 @@ Aqui estão alguns desafios basicos para você testar suas habilidades. (Obs: N�
 | 02  | ....  |    |
 | 03  | .....  |   |
 
-[Voltar ao Inicio](../README.md)
+[Início](../README.md), [Anterior](./3-Comeco)
 
 <p align="center">
   <a href="https://github.com/he4rt/4noobs" target="_blank">


### PR DESCRIPTION
Adicionei os links de navegação na página começo, que estava faltando, e fiz algumas correções nas outras páginas. Na página Historia eu removi o link anterior, pois ela é a primeira página, e também já possuia um link pro README. Também fiz correções de acentuação no texto dos links que são exibidos.